### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+name: Release with goreleaser
+on:
+  push:
+    tags:
+      - v*.*.*
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: goreleaser
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Release via goreleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ tfk8s [![Go Report Card](https://goreportcard.com/badge/github.com/jrhouston/tfk
 
 `tfk8s` is a tool that makes it easier to work with the [Terraform Kubernetes Provider](https://github.com/hashicorp/terraform-provider-kubernetes).
 
-If you want to copy examples from the Kubernetes documentation or migrate existing YAML manifests and use them with Terraform without having to convert YAML to HCL by hand, this tool is for you. 
+If you want to copy examples from the Kubernetes documentation or migrate existing YAML manifests and use them with Terraform without having to convert YAML to HCL by hand, this tool is for you.
 
-## Demo 
+## Demo
 
 [<img src="https://asciinema.org/a/jSmyAg4Ar6EcwKCTCXN8iAJM2.svg" width="250">](https://asciinema.org/a/jSmyAg4Ar6EcwKCTCXN8iAJM2)
 
@@ -19,6 +19,7 @@ If you want to copy examples from the Kubernetes documentation or migrate existi
 
 ## Install
 
+#### Option 1: go install
 ```
 go install github.com/jrhouston/tfk8s@latest
 ```
@@ -34,6 +35,15 @@ If Go's bin directory is not in your `PATH` you will need to add it:
 ```
 export PATH=$PATH:$(go env GOPATH)/bin
 ```
+
+#### Option 2: GitHub release
+
+1. Download the [latest](https://github.com/jrhouston/tfk8s/releases/latest) release’s tarball for your client platform.
+2. Extract the tarball:
+```sh
+tar -xvf <RELEASE-TARBALL-NAME>.tar.gz
+```
+3. Move the extracted tfk8s binary to somewhere in your $PATH (/usr/local/bin for most users).
 
 ## Usage
 


### PR DESCRIPTION
Helps #5 

This PR adds an action to build the binaries and create a release just by creating a tag.

## How to create a release
```sh
git tag <new-tag>
git push origin  <new-tag>
```

## Release output

![image](https://user-images.githubusercontent.com/18387694/139726082-618b5289-b970-49e6-af02-9267f8dd785c.png)


Then the users can:

1. Download the [latest](https://github.com/jrhouston/tfk8s/releases/latest) release’s tarball for your client platform.
2. Extract the tarball:
```sh
tar -xvf <RELEASE-TARBALL-NAME>.tar.gz
```
3. Move the extracted tfk8s binary to somewhere in your $PATH (/usr/local/bin for most users).