### PR TITLE
regex wouldn't match nested interpolation

### DIFF
--- a/tfk8s.go
+++ b/tfk8s.go
@@ -90,7 +90,7 @@ func snakify(s string) string {
 
 // escape incidences of ${} with $${} to prevent Terraform trying to interpolate them
 func escapeShellVars(s string) string {
-	r := regexp.MustCompile(`(\${.*?})`)
+	r := regexp.MustCompile(`(\${.*?)`)
 	return r.ReplaceAllString(s, `$$$1`)
 }
 

--- a/tfk8s_test.go
+++ b/tfk8s_test.go
@@ -81,7 +81,8 @@ metadata:
   name: test
 data:
   SCRIPT: |
-    echo Hello, ${USER} your homedir is ${HOME}`
+    echo "Hello, ${USER} your homedir is ${HOME}"
+    echo "\${SHELL_ESCAPE${TF_ESCAPE}}"`
 
 	r := strings.NewReader(yaml)
 	output, err := YAMLToTerraformResources(r, "", false, false, false)
@@ -95,7 +96,10 @@ resource "kubernetes_manifest" "configmap_test" {
   manifest = {
     "apiVersion" = "v1"
     "data" = {
-      "SCRIPT" = "echo Hello, $${USER} your homedir is $${HOME}"
+      "SCRIPT" = <<-EOT
+      echo "Hello, $${USER} your homedir is $${HOME}"
+      echo "\$${SHELL_ESCAPE$${TF_ESCAPE}}"
+      EOT
     }
     "kind" = "ConfigMap"
     "metadata" = {
@@ -117,8 +121,8 @@ data:
   TEST: one
 ---
 # this empty
-# document 
-# should be 
+# document
+# should be
 # skipped
 ---
 apiVersion: v1


### PR DESCRIPTION
I needed to convert the argocd yaml manifests, which worked nicely except for two lines.
Noticed that `tfk8s` only escaped the first occurrence of `${`, but skipped the second,
 when using nested interpolations from heredoc-shell-scripts.

## how to reproduce

```sh
cat <<EOF > kustomization.yaml
---
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

namespace: argocd

resources:
- https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/ha/install.yaml
EOF

kustomize build . | tfk8s > kubernetes.tf

cat <<EOF > main.tf
terraform {
  required_providers {
    kubernetes = {
      source = "hashicorp/kubernetes"
      version = "2.9.0"
    }
  }
}

provider "kubernetes" {
  # Configuration options
}
EOF

terraform init && terraform apply
```

will result ih

```sh
╷
│ Error: Invalid reference
│
│   on kubernetes.tf line 13243, in resource "kubernetes_manifest" "configmap_argocd_argocd_redis_ha_configmap":
│ 13243:           echo "  evaluating sentinel id (\$${SENTINEL_ID_${INDEX}})"
│
│ A reference to a resource type must be followed by at least one attribute access, specifying the resource name.
╵
╷
│ Error: Invalid reference
│
│   on kubernetes.tf line 13404, in resource "kubernetes_manifest" "configmap_argocd_argocd_redis_ha_configmap":
│ 13404:           index=$${1:-${INDEX}}
│
│ A reference to a resource type must be followed by at least one attribute access, specifying the resource name.
╵
```

## used version

```sh
$ tfk8s --version
0.1.8

$ terraform version
Terraform v1.1.3
on darwin_amd64
+ provider registry.terraform.io/hashicorp/kubernetes v2.9.0

$ terraform providers

Providers required by configuration:
.
└── provider[registry.terraform.io/hashicorp/kubernetes] 2.9.0
```